### PR TITLE
[Setup] Run deployCommands on bot startup

### DIFF
--- a/deploy-commands.js
+++ b/deploy-commands.js
@@ -1,18 +1,22 @@
-const fs = require('fs');
-const { REST } = require('@discordjs/rest');
-const { Routes } = require('discord-api-types/v9');
-const { clientId, guildId, token } = require('./config.json');
+const deployCommands = () => {
+	const fs = require('fs');
+	const { REST } = require('@discordjs/rest');
+	const { Routes } = require('discord-api-types/v9');
+	const { clientId, guildId, token } = require('./config.json');
 
-const commands = [];
-const commandFiles = fs.readdirSync('./commands').filter(file => file.endsWith('.js'));
+	const commands = [];
+	const commandFiles = fs.readdirSync('./commands').filter(file => file.endsWith('.js'));
 
-for (const file of commandFiles) {
-	const command = require(`./commands/${file}`);
-	commands.push(command.data.toJSON());
-}
+	for (const file of commandFiles) {
+		const command = require(`./commands/${file}`);
+		commands.push(command.data.toJSON());
+	}
 
-const rest = new REST({ version: '9' }).setToken(token);
+	const rest = new REST({ version: '9' }).setToken(token);
 
-rest.put(Routes.applicationGuildCommands(clientId, guildId), { body: commands })
-	.then(() => console.log('Successfully registered application commands.'))
-	.catch(console.error);
+	rest.put(Routes.applicationGuildCommands(clientId, guildId), { body: commands })
+		.then(() => console.log('Successfully registered application commands.'))
+		.catch(console.error);
+};
+
+module.exports = deployCommands;

--- a/index.js
+++ b/index.js
@@ -5,6 +5,7 @@ const { SlashCommandBuilder } = require('@discordjs/builders');
 const fetch = require('node-fetch')
 const triggers = require("./triggers.json")
 const censored = require('./censored.json')
+const deployCommands = require('./deploy-commands')
 
 const client = new Client({
 	intents: [
@@ -25,6 +26,9 @@ for (const file of commandFiles) {
 client.once('ready', async c => {
 	console.log(`Ready! Logged in as ${c.user.tag}`);
 	client.user.setActivity(config.server_name, { type: 'WATCHING' })
+
+	// Setup slash commands
+	deployCommands();
 });
 
 client.on('unhandledRejection', error => {


### PR DESCRIPTION
This simplifies the process of adding new slash commands, as you don't have to `node deploy-commands.js` each time you add or modify a command.